### PR TITLE
Добавить утилитарный метод конкатинации объектов

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 yarn-error.log
 /dist
 /public
+/.idea
 

--- a/src/editor/history.ts
+++ b/src/editor/history.ts
@@ -1,5 +1,6 @@
 import type { Token } from '../parser';
 import type { TextRange } from './types';
+import { objectMerge } from '../utils/objectMerge';
 
 export interface HistoryOptions {
     /** Список действий, которые можно схлопнуть в одно */
@@ -33,10 +34,7 @@ export default class History<S = Token[]> {
     private _ptr = -1;
 
 	constructor(options?: Partial<HistoryOptions>) {
-		this.options = {
-			...defaultOptions,
-			...options
-		};
+		this.options = objectMerge(defaultOptions, options);
 	}
 
 	/**

--- a/src/editor/index.ts
+++ b/src/editor/index.ts
@@ -13,6 +13,7 @@ import { getInputText, isElement } from './utils';
 import parseHTML from '../parser/html2';
 import toHTML from '../render/html';
 import { last } from '../parser/utils';
+import { objectMerge } from '../utils/objectMerge';
 
 const enum DiffActionType {
     Insert = 'insert',
@@ -655,10 +656,7 @@ export default class Editor {
             markdownUpdated = options.parse.markdown !== markdown;
         }
 
-        this.options = {
-            ...this.options,
-            ...options
-        };
+        this.options = objectMerge(this.options, options);
 
         if (markdownUpdated) {
             const sel = this.getSelection();
@@ -804,7 +802,7 @@ export default class Editor {
 
         return typeof text === 'string'
             ? sanitize(text, nowrap) as T
-            : text.map(t => ({ ...t, value: sanitize(t.value, nowrap) })) as T;
+            : text.map(t => objectMerge(t, { value: sanitize(t.value, nowrap) })) as T;
     }
 
     private getCompositionRange(): TextRange {

--- a/src/formatted-string/index.ts
+++ b/src/formatted-string/index.ts
@@ -6,6 +6,7 @@ import {
     tokenForPos, isSolidToken, isCustomLink, isAutoLink, splitToken,
     sliceToken, toLink, toText, tokenRange, createToken
 } from './utils';
+import { objectMerge } from '../utils/objectMerge';
 
 export { mdToText, textToMd, tokenForPos }
 export type { CutText, TokenFormatUpdate, TextRange }
@@ -89,10 +90,9 @@ export function setFormat(tokens: Token[], format: TokenFormatUpdate | TokenForm
         for (let i = start.index + 1, nextFormat: TokenFormat; i < end.index; i++) {
             nextFormat = applyFormat(tokens[i].format, format);
             if (tokens[i].format !== nextFormat) {
-                tokens[i] = {
-                    ...tokens[i],
+                tokens[i] = objectMerge(tokens[i], {
                     format: nextFormat
-                };
+                });
             }
         }
 
@@ -395,7 +395,7 @@ function applyFormatAt(tokens: Token[], tokenIndex: number, update: TokenFormatU
 
     if (pos === 0 && len === token.value.length) {
         // Частный случай: меняем формат у всего токена
-        nextTokens = [{ ...token, format }];
+        nextTokens = [objectMerge(token, { format })];
     } else {
         // Делим токен на части. Если это специальный токен типа хэштэга
         // или команды, превратим его в обычный текст

--- a/src/formatted-string/utils.ts
+++ b/src/formatted-string/utils.ts
@@ -1,5 +1,6 @@
 import { TokenType, TokenFormat } from '../parser';
 import type { Token, Emoji, TokenLink, TokenText } from '../parser';
+import { objectMerge } from '../utils/objectMerge';
 
 export interface TokenForPos {
     /** Индекс найденного токена (будет -1, если такой токен не найден) */
@@ -124,11 +125,10 @@ export function splitToken(token: Token, pos: number): [Token, Token] {
  */
 export function sliceToken(token: Token, start: number, end = token.value.length): Token {
     const { value, emoji } = token;
-    const result = {
-        ...token,
+    const result = objectMerge(token, {
         value: value.slice(start, end),
         emoji: sliceEmoji(emoji, start, end)
-    };
+    });
 
     if (result.type === TokenType.Link) {
         // Если достаём фрагмент автоссылки, то убираем это признак
@@ -191,8 +191,7 @@ export function isAutoLink(token: Token): token is TokenLink {
 }
 
 function shiftEmoji(emoji: Emoji[], offset: number): Emoji[] {
-    return emoji.map(e => ({
-        ...e,
+    return emoji.map(e => objectMerge(e, {
         from: e.from + offset,
         to: e.to + offset
     }));

--- a/src/parser/html2.ts
+++ b/src/parser/html2.ts
@@ -12,6 +12,7 @@ import link from './link';
 import { consumeNewline } from './newline';
 import { setLink } from '../formatted-string';
 import { trim } from '../formatted-string/split';
+import { objectMerge } from '../utils/objectMerge';
 
 interface HTMLParserOptions {
     /** Разрешать парсить ссылки */
@@ -111,10 +112,9 @@ class HTMLParseState {
     options: HTMLParserOptions;
 
     constructor(opt?: Partial<HTMLParserOptions>) {
-        this.options = {
-            links: false,
-            ...opt
-        };
+        this.options = objectMerge({
+            links: false
+        }, opt);
     }
 
     pushText(text: string) {
@@ -160,10 +160,9 @@ class HTMLParseState {
             text = text.replace(/[\s\r\n]+/g, ' ');
         }
 
-        const state = new ParserState(text, {
-            ...defaultOptions,
+        const state = new ParserState(text, objectMerge(defaultOptions, {
             useFormat: true
-        });
+        }));
         state.format = this.format;
 
         if (this.link) {

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -11,9 +11,10 @@ import link from './link';
 import markdown from './markdown';
 import newline from './newline';
 import { normalize, defaultOptions } from './utils';
+import { objectMerge } from '../utils/objectMerge';
 
 export default function parse(text: string, opt?: Partial<ParserOptions>): Token[] {
-    const options: ParserOptions = { ...defaultOptions, ...opt };
+    const options: ParserOptions = objectMerge(defaultOptions, opt);
     const state = new ParserState(text, options);
 
     while (state.hasNext()) {

--- a/src/parser/utils.ts
+++ b/src/parser/utils.ts
@@ -1,6 +1,7 @@
 import { TokenFormat, TokenType } from './types';
 import type { ParserOptions, Emoji, Token, TokenLink } from './types';
 import type ParserState from './state';
+import { objectMerge } from '../utils/objectMerge';
 
 export const Codes = {
     // Formatting
@@ -411,7 +412,7 @@ function joinSimilar(tokens: Token[]): Token[] {
     return tokens.reduce((out, token) => {
         let prev = out[out.length - 1];
         if (prev && allowJoin(prev, token)) {
-            prev = { ...prev };
+            prev = objectMerge(prev);
 
             if (token.emoji) {
                 const nextEmoji = shiftEmoji(token.emoji, prev.value.length);
@@ -439,8 +440,7 @@ function allowJoin(token1: Token, token2: Token): boolean {
 }
 
 function shiftEmoji(emoji: Emoji[], offset: number): Emoji[] {
-    return emoji.map(e => ({
-        ...e,
+    return emoji.map(e => objectMerge(e, {
         from: e.from + offset,
         to: e.to + offset
     }));

--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -1,6 +1,7 @@
 import { isAutoLink, isCustomLink } from '../formatted-string/utils';
 import type { Emoji, Token, TokenHashTag, TokenLink, TokenMention, TokenCommand, TokenText } from '../parser';
 import { TokenFormat, TokenType } from '../parser';
+import { objectMerge } from '../utils/objectMerge';
 
 declare global {
     interface Element {
@@ -78,7 +79,7 @@ const defaultOptions: RenderOptions = {
 }
 
 export default function render(elem: HTMLElement, tokens: Token[], opt?: Partial<RenderOptions>): void {
-    const options: RenderOptions = opt ? { ...defaultOptions, ...opt } : defaultOptions;
+    const options: RenderOptions = opt ? objectMerge(defaultOptions, opt) : defaultOptions;
 
     if (options.inline) {
         renderInline(elem, tokens, options);

--- a/src/utils/objectMerge.ts
+++ b/src/utils/objectMerge.ts
@@ -1,0 +1,1 @@
+export const objectMerge = <T>(...args: (T | Partial<T>)[]): T => Object.assign({}, ...args);


### PR DESCRIPTION
Для избавления от необходимости прогонять через транспайлер, добавлена функция для объединения объектов.
Сделано для поддержки старых браузеров (chrome46), т.к. поддержка спред литералов объектов была добавлена позже массивов и не работает в некоторых браузерах.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax